### PR TITLE
Fix variable referenced before assignment error

### DIFF
--- a/varspeed/varspeed.py
+++ b/varspeed/varspeed.py
@@ -100,6 +100,7 @@ class Vspeed():
       changed = True
 
     # restrict the output to integer if needed (e.g. for a servo)
+    position = self.position
     if self.result == "int":
       position = round(self.position)
 


### PR DESCRIPTION
When instantiating the `Vspeed` class using `result="float"` instead of `result="int"` the code produces the following error:
```
Traceback (most recent call last):
  File "main.py", line 105, in <module>
  File "/lib/varspeed.py", line 172, in sequence
  File "/lib/varspeed.py", line 108, in move
NameError: local variable referenced before assignment
```

This happens because in lines 102 to 108:
```
    # restrict the output to integer if needed (e.g. for a servo)
    if self.result == "int":
      position = round(self.position)

    # restrict the output to be within the bounds set by set_bounds()
    if self.bounded:
      position = max(self.lower_bound, min(position, self.upper_bound))
```

If `self.result` is not `"int"`, then the `position` variable is never created.
This can easily be fixed with a `position = self.position` right before the if statement.
      